### PR TITLE
add pr-agent

### DIFF
--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -1,0 +1,41 @@
+name: PR-Agent
+
+# pr_comment_for_pr_agent.yml のコメントによって起動する
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  pr_agent:
+    # PR or PRのコメントの場合に実行する
+    # if: ${{ (github.event.sender.type == 'Bot' || github.event.sender.login == 'zakizaki-ri9') && (github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request)) }}
+    if: ${{ (github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request)) }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: write
+    name: Run PR Agent
+    steps:
+      - id: pr-agent
+        uses: Codium-ai/pr-agent@main
+        env:
+          OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # 次の中からモデルを指定
+          # https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/algo/__init__.py
+          CONFIG.MODEL: "o1-mini"
+          PR_REVIEWER.EXTRA_INSTRUCTIONS: "Please be sure to answer in Japanese. 必ず日本語で回答してください。"
+          PR_DESCRIPTION.EXTRA_INSTRUCTIONS: "Please be sure to answer in Japanese. 必ず日本語で回答してください。タイトルは commitlint パターンの接頭辞を含む必要があります。"
+          PR_CODE_SUGGESTIONS.EXTRA_INSTRUCTIONS: "Please be sure to answer in Japanese. 必ず日本語で回答してください。"
+          PR_ADD_DOCS.EXTRA_INSTRUCTIONS: "Please be sure to answer in Japanese. 必ず日本語で回答してください。"
+          PR_UPDATE_CHANGELOG.EXTRA_INSTRUCTIONS: "Please be sure to answer in Japanese. 必ず日本語で回答してください。"
+          PR_TEST.EXTRA_INSTRUCTIONS: "Please be sure to answer in Japanese. 必ず日本語で回答してください。"
+          PR_IMPROVE_COMPONENT.EXTRA_INSTRUCTIONS: "Please be sure to answer in Japanese. 必ず日本語で回答してください。"
+          PR_REVIEWER.ENABLE_REVIEW_LABELS_SECURITY: false
+          PR_REVIEWER.ENABLE_REVIEW_LABELS_EFFORT: false
+          PR_DESCRIPTION.PUBLISH_LABELS: false
+          PR_CODE_SUGGESTIONS.NUM_CODE_SUGGESTIONS_PER_CHUNK: 10
+          PR_CODE_SUGGESTIONS.NUM_CODE_SUGGESTIONS: 10
+          # CONFIG.IGNORE_PR_TITLE: "['WIP']"
+          # CONFIG.IGNORE_PR_SOURCE_BRANCH: [develop, main]

--- a/.github/workflows/pr_agent_for_comment.yml
+++ b/.github/workflows/pr_agent_for_comment.yml
@@ -1,0 +1,54 @@
+name: PR Comment for PR-Agent
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  pr_comment_for_pr_agent:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Find and Delete Comments
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue_number = ${{ github.event.pull_request.number }};
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+            });
+
+            const commentsToDelete = comments.data.filter(comment =>
+              ['/review', '/describe', '/improve'].includes(comment.body)
+            );
+
+            for (const comment of commentsToDelete) {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: comment.id,
+              });
+            }
+
+      - name: Post Comments
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue_number = ${{ github.event.pull_request.number }};
+            const commentsToPost = ['/review', '/describe', '/improve'];
+
+            for (const comment of commentsToPost) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue_number,
+                body: comment,
+              });
+            }


### PR DESCRIPTION
https://github.com/zakizaki-ri9/blog/pull/50 の復活

This pull request introduces new GitHub Actions workflows to automate interactions with the PR-Agent. The workflows are designed to trigger actions based on pull request events and issue comments, and manage comments on pull requests.

New GitHub Actions workflows:

* [`.github/workflows/pr_agent.yml`](diffhunk://#diff-fc2b2ed01cad745cb09e9c20e7c91db7f4f1eb9796abb84bbdce7dd0f77dace8R1-R41): Adds a workflow named "PR-Agent" that triggers on issue comments and runs the PR-Agent with specific environment variables to ensure responses are in Japanese.
* [`.github/workflows/pr_agent_for_comment.yml`](diffhunk://#diff-5396196ca1064d02586b7cd3b6ec4aef13afb4110e9384514e45fcc97a3d4bb2R1-R54): Adds a workflow named "PR Comment for PR-Agent" that triggers on pull request events to manage comments by deleting specific comments and posting new ones.